### PR TITLE
Misc fixes

### DIFF
--- a/idom_jupyter/__init__.py
+++ b/idom_jupyter/__init__.py
@@ -2,7 +2,8 @@ from ._version import version_info  # noqa
 from ._version import __version__  # noqa
 
 from . import jupyter_server_extension
-from .widget import LayoutWidget, widgetize, run, set_jupyter_server_base_url
+from .import_resources import setup_import_resources
+from .widget import LayoutWidget, widgetize, run, set_import_source_base_url
 from .ipython_extension import load_ipython_extension, unload_ipython_extension
 
 
@@ -12,9 +13,12 @@ __all__ = [
     "run",
     "load_ipython_extension",
     "unload_ipython_extension",
-    "set_jupyter_server_base_url",
+    "set_import_source_base_url",
     "jupyter_server_extension",
 ]
+
+
+setup_import_resources()
 
 
 def _jupyter_labextension_paths():

--- a/idom_jupyter/_version.py
+++ b/idom_jupyter/_version.py
@@ -1,5 +1,5 @@
 # Module version
-version_info = (0, 6, 5, "final", 0)
+version_info = (0, 7, 0, "final", 0)
 
 # Module version stage suffix map
 _specifier_ = {"alpha": "a", "beta": "b", "candidate": "rc", "final": ""}

--- a/idom_jupyter/import_resources.py
+++ b/idom_jupyter/import_resources.py
@@ -1,0 +1,110 @@
+import logging
+import socket
+from uuid import uuid4
+from contextlib import closing
+from multiprocessing import Process
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+
+import requests
+from notebook import notebookapp
+
+from .jupyter_server_extension import IDOM_RESOURCE_BASE_PATH, IDOM_WEB_MODULES_DIR
+from .widget import set_import_source_base_url
+
+
+logger = logging.getLogger(__name__)
+
+
+def setup_import_resources():
+    if _try_to_set_import_source_base_url():
+        return None
+
+    host = "127.0.0.1"
+    port = _find_available_port("127.0.0.1")
+
+    logger.debug(
+        f"Serving web modules via local static file server at http://{host}:{port}/"
+    )
+    serve_dir = str(IDOM_WEB_MODULES_DIR.current)
+
+    proc = Process(
+        target=lambda: _run_simple_static_file_server(host, port, serve_dir),
+        daemon=True,
+    )
+    proc.start()
+
+
+def _try_to_set_import_source_base_url() -> bool:
+    # Try to see if there's a local server we should use. This might happen when running
+    # in a notebook from within VSCode
+    _temp_file_name = f"__temp_{uuid4().hex}__"
+    _temp_file = IDOM_WEB_MODULES_DIR.current / _temp_file_name
+    _temp_file.touch()
+    for _server_info in notebookapp.list_running_servers():
+        if _server_info["hostname"] not in ("localhost", "127.0.0.1"):
+            continue
+
+        _resource_url_parts = [
+            _server_info["url"].rstrip("/"),
+            _server_info["base_url"].strip("/"),
+            IDOM_RESOURCE_BASE_PATH,
+        ]
+        _resource_url = "/".join(filter(None, _resource_url_parts))
+        _temp_file_url = _resource_url + "/" + _temp_file_name
+
+        response = requests.get(_temp_file_url, params={"token": _server_info["token"]})
+
+        if response.status_code == 200:
+            set_import_source_base_url(_resource_url)
+            logger.debug(
+                f"Serving web modules via existing NotebookApp server at {_resource_url!r}"
+            )
+            return True
+    _temp_file.unlink()
+    return False
+
+
+def _run_simple_static_file_server(host, port, directory):
+    class CORSRequestHandler(SimpleHTTPRequestHandler):
+        def end_headers(self):
+            self.send_header("Access-Control-Allow-Origin", "*")
+            SimpleHTTPRequestHandler.end_headers(self)
+
+        def log_message(self, format, *args):
+            logger.info(
+                "%s - - [%s] %s\n"
+                % (self.address_string(), self.log_date_time_string(), format % args)
+            )
+
+    def make_cors_handler(*args, **kwargs):
+        return CORSRequestHandler(*args, directory=directory, **kwargs)
+
+    with HTTPServer((host, port), make_cors_handler) as httpd:
+        httpd.serve_forever()
+
+
+def _find_available_port(
+    host: str,
+    port_min: int = 8000,
+    port_max: int = 9000,
+    allow_reuse_waiting_ports: bool = True,
+) -> int:
+    """Get a port that's available for the given host and port range"""
+    for port in range(port_min, port_max):
+        with closing(socket.socket()) as sock:
+            try:
+                if allow_reuse_waiting_ports:
+                    # As per this answer: https://stackoverflow.com/a/19247688/3159288
+                    # setting can be somewhat unreliable because we allow the use of
+                    # ports that are stuck in TIME_WAIT. However, not setting the option
+                    # means we're overly cautious and almost always use a different addr
+                    # even if it could have actually been used.
+                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                sock.bind((host, port))
+            except OSError:
+                pass
+            else:
+                return port
+    raise RuntimeError(
+        f"Host {host!r} has no available port in range {port_max}-{port_max}"
+    )

--- a/idom_jupyter/jupyter_server_extension.py
+++ b/idom_jupyter/jupyter_server_extension.py
@@ -1,26 +1,33 @@
+from typing import Any
 from urllib.parse import urljoin
 
 from appdirs import user_data_dir
 from notebook.notebookapp import NotebookApp
-from idom.config import IDOM_WED_MODULES_DIR
-from tornado.web import StaticFileHandler
+from notebook.base.handlers import AuthenticatedFileHandler
+
 from tornado.web import Application
 
+try:
+    from idom.config import IDOM_WEB_MODULES_DIR
+except ImportError:
+    from idom.config import IDOM_WED_MODULES_DIR as IDOM_WEB_MODULES_DIR
 
-IDOM_WED_MODULES_DIR.current = user_data_dir("idom-jupyter", "idom-team")
+
+IDOM_WEB_MODULES_DIR.current = user_data_dir("idom-jupyter", "idom-team")
+IDOM_RESOURCE_BASE_PATH = "_idom_web_modules"
 
 
 def _load_jupyter_server_extension(notebook_app: NotebookApp):
     web_app: Application = notebook_app.web_app
     base_url = web_app.settings["base_url"]
-    route_pattern = urljoin(base_url, rf"_idom_web_modules/(.*)")
+    route_pattern = urljoin(base_url, rf"{IDOM_RESOURCE_BASE_PATH}/(.*)")
     web_app.add_handlers(
         host_pattern=r".*$",
         host_handlers=[
             (
                 route_pattern,
-                StaticFileHandler,
-                {"path": str(IDOM_WED_MODULES_DIR.current.absolute())},
+                AuthenticatedFileHandler,
+                {"path": str(IDOM_WEB_MODULES_DIR.current.absolute())},
             ),
         ],
     )

--- a/idom_jupyter/widget.py
+++ b/idom_jupyter/widget.py
@@ -13,12 +13,13 @@ from idom.core.layout import Layout, LayoutEvent, LayoutUpdate
 from idom.core.dispatcher import VdomJsonPatch, render_json_patch
 
 
-_JUPYTER_SERVER_BASE_URL = ""
+_IMPORT_SOURCE_BASE_URL = ""
 
 
-def set_jupyter_server_base_url(base_url):
-    global _JUPYTER_SERVER_BASE_URL
-    _JUPYTER_SERVER_BASE_URL = base_url
+def set_import_source_base_url(base_url):
+    """Fallback URL for import sources, if no Jupyter Server is discovered by the client"""
+    global _IMPORT_SOURCE_BASE_URL
+    _IMPORT_SOURCE_BASE_URL = base_url
 
 
 def run(constructor):
@@ -56,14 +57,14 @@ class LayoutWidget(widgets.DOMWidget):
     _model_module = Unicode("idom-client-jupyter").tag(sync=True)
 
     # Version of the front-end module containing widget view
-    _view_module_version = Unicode("^0.4.0").tag(sync=True)
+    _view_module_version = Unicode("^0.7.0").tag(sync=True)
     # Version of the front-end module containing widget model
-    _model_module_version = Unicode("^0.4.0").tag(sync=True)
+    _model_module_version = Unicode("^0.7.0").tag(sync=True)
 
-    _jupyter_server_base_url = Unicode().tag(sync=True)
+    _import_source_base_url = Unicode().tag(sync=True)
 
     def __init__(self, component: ComponentType):
-        super().__init__(_jupyter_server_base_url=_JUPYTER_SERVER_BASE_URL)
+        super().__init__(_import_source_base_url=_IMPORT_SOURCE_BASE_URL)
         self._idom_model = {}
         self._idom_views = set()
         self._idom_layout = Layout(component)

--- a/js/lib/widget.js
+++ b/js/lib/widget.js
@@ -8,8 +8,8 @@ var IdomModel = widgets.DOMWidgetModel.extend({
     _view_name: "IdomView",
     _model_module: "idom-client-jupyter",
     _view_module: "idom-client-jupyter",
-    _model_module_version: "0.4.0",
-    _view_module_version: "0.4.0",
+    _model_module_version: "0.7.0",
+    _view_module_version: "0.7.0",
   }),
 });
 
@@ -55,12 +55,24 @@ class IdomView extends widgets.DOMWidgetView {
       });
     };
 
-    const importSourceBaseUrl = concatAndResolveUrl(
-      this.model.attributes._jupyter_server_base_url || jupyterServerBaseUrl,
-      "_idom_web_modules"
-    );
+    let importSourceBaseUrl;
+    if (jupyterServerBaseUrl) {
+      importSourceBaseUrl = concatAndResolveUrl(
+        jupyterServerBaseUrl,
+        "_idom_web_modules"
+      );
+    } else {
+      importSourceBaseUrl = this.model.attributes._import_source_base_url;
+    }
+    if (!importSourceBaseUrl) {
+      console.error(
+        "No Jupyter Server base URL could be discovered and no import source base URL was configured."
+      );
+    }
+
     var loadImportSource = (source, sourceType) => {
-      return import( /* webpackIgnore: true */
+      return import(
+        /* webpackIgnore: true */
         sourceType == "NAME" ? `${importSourceBaseUrl}/${source}` : source
       );
     };

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idom-client-jupyter",
-  "version": "0.4.0",
+  "version": "0.6.5",
   "description": "A client for IDOM implemented using Jupyter widgets",
   "author": "Ryan Morshead",
   "main": "lib/index.js",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idom-client-jupyter",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "A client for IDOM implemented using Jupyter widgets",
   "author": "Ryan Morshead",
   "main": "lib/index.js",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup_args = dict(
     description="A client for IDOM implemented using Jupyter widgets",
     long_description=LONG_DESCRIPTION,
     include_package_data=True,
-    install_requires=["ipywidgets>=7.6.0", "idom>=0.36.0,<0.37", "appdirs"],
+    install_requires=["ipywidgets>=7.6.0", "idom>=0.36.0,<0.37", "appdirs", "requests"],
     packages=find_packages(),
     zip_safe=False,
     cmdclass=cmdclass,


### PR DESCRIPTION
- Make server extension authenticated
- Try to determine if running with adjacent notebook server,
  and if not, spawn static file server from which to provide
  web modules. This will probably just be used by VSCode.
- rename _jupyter_server_base_url to _import_source_base_url
  to better indicate that this is a manually specified
  location where web modules are served rather than a jupyter
  server (though it might be).
- bump model and view versions for everything.