### PR TITLE
Reroute docs away from heroku

### DIFF
--- a/notebooks/introduction.ipynb
+++ b/notebooks/introduction.ipynb
@@ -8,9 +8,9 @@
     "\n",
     "ReactPy connects your Python web framework of choice to a ReactJS frontend, allowing you to create **interactive websites without needing JavaScript!**\n",
     "\n",
-    "Following ReactJS styling, web elements are combined into [reusable \"components\"](https://reactpy-docs.herokuapp.com/docs/guides/creating-interfaces/your-first-components/index.html#parametrizing-components). These components can utilize [hooks](https://reactpy-docs.herokuapp.com/docs/reference/hooks-api.html) and [events](https://reactpy-docs.herokuapp.com/docs/guides/adding-interactivity/responding-to-events/index.html#async-event-handlers) to create infinitely complex web pages.\n",
+    "Following ReactJS styling, web elements are combined into [reusable \"components\"](https://reactpy.dev/docs/guides/creating-interfaces/your-first-components/index.html#parametrizing-components). These components can utilize [hooks](https://reactpy.dev/docs/reference/hooks-api.html) and [events](https://reactpy.dev/docs/guides/adding-interactivity/responding-to-events/index.html#async-event-handlers) to create infinitely complex web pages.\n",
     "\n",
-    "When needed, ReactPy can [use components directly from NPM](https://reactpy-docs.herokuapp.com/docs/guides/escape-hatches/javascript-components.html#dynamically-loaded-components). For additional flexibility, components can also be [fully developed in JavaScript](https://reactpy-docs.herokuapp.com/docs/guides/escape-hatches/javascript-components.html#custom-javascript-components).\n",
+    "When needed, ReactPy can [use components directly from NPM](https://reactpy.dev/docs/guides/escape-hatches/javascript-components.html#dynamically-loaded-components). For additional flexibility, components can also be [fully developed in JavaScript](https://reactpy.dev/docs/guides/escape-hatches/javascript-components.html#custom-javascript-components).\n",
     "\n",
     "\n",
     "# Getting Started\n",
@@ -79,7 +79,7 @@
     "\n",
     "ReactPy is a Python package for making user interfaces (UI). These interfaces are built from small elements of functionality like buttons text and images. ReactPy allows you to combine these elements into reusable “components”. Once you learn how these UI elements are created and organized into components you'll be able to do things like create interfaces from raw data:\n",
     "\n",
-    "<a href=\"https://reactpy-docs.herokuapp.com/docs/creating-interfaces/index.html\" target=\"_blank\"><button>Read More!</button></a>"
+    "<a href=\"https://reactpy.dev/docs/guides/creating-interfaces/index.html\" target=\"_blank\"><button>Read More!</button></a>"
    ]
   },
   {
@@ -132,7 +132,7 @@
     "\n",
     "Components often need to change what’s on the screen as a result of an interaction. For example, typing into the form should update the input field, clicking a “Comment” button should bring up a text input field, clicking “Buy” should put a product in the shopping cart. Components need to “remember” things like the current input value, the current image, the shopping cart. In ReactPy, this kind of component-specific memory is created and updated with a “hook” called use_state() that creates a state variable and state setter respectively:\n",
     "\n",
-    "<a href=\"https://reactpy-docs.herokuapp.com/docs/adding-interactivity/index.html\" target=\"_blank\"><button>Read More!</button></a>"
+    "<a href=\"https://reactpy.dev/docs/guides/adding-interactivity/index.html\" target=\"_blank\"><button>Read More!</button></a>"
    ]
   },
   {
@@ -186,7 +186,7 @@
    "source": [
     "# Using ReactPy With Jupyter Widgets\n",
     "\n",
-    "While you can use ReactPy components independently, it may also be useful to integrate them with the rest of the Jupyter Widget ecosystem. Let's consider an ReactPy component that responds to and displays changes from an `ipywidgets.IntSlider`. The ReactPy component will need to accept an `IntSlider` instance as one of its arguments, declare state that will track the slider's value, and register a lister that will update that state via the slider's `IntSlider.observe()` method using an [\"effect\"](https://reactpy-docs.herokuapp.com/docs/reference/hooks-api.html#use-effect):"
+    "While you can use ReactPy components independently, it may also be useful to integrate them with the rest of the Jupyter Widget ecosystem. Let's consider an ReactPy component that responds to and displays changes from an `ipywidgets.IntSlider`. The ReactPy component will need to accept an `IntSlider` instance as one of its arguments, declare state that will track the slider's value, and register a lister that will update that state via the slider's `IntSlider.observe()` method using an [\"effect\"](https://reactpy.dev/docs/reference/hooks-api.html#use-effect):"
    ]
   },
   {
@@ -281,7 +281,7 @@
     "\n",
     "While ReactPy is a great tool for displaying HTML and responding to browser events with pure Python, there are other projects which already allow you to do this inside Jupyter Notebooks or in standard web apps. The real power of ReactPy comes from its ability to seamlessly leverage the existing Javascript ecosystem:\n",
     "\n",
-    "<a href=\"https://reactpy-docs.herokuapp.com/docs/escape-hatches/javascript-components.html\" target=\"_blank\"><button>Read More!</button></a>"
+    "<a href=\"https://reactpy.dev/docs/guides/escape-hatches/javascript-components.html\" target=\"_blank\"><button>Read More!</button></a>"
    ]
   },
   {
@@ -312,7 +312,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# [Learn More!](https://reactpy-docs.herokuapp.com)"
+    "# [Learn More!](https://reactpy.dev/docs/index.html)"
    ]
   },
   {


### PR DESCRIPTION
Examples were linked to heroku instead of reactpy.dev